### PR TITLE
Enable Saving Segment Related Information In Runtime Connections

### DIFF
--- a/opm/simulators/wells/RuntimePerforation.hpp
+++ b/opm/simulators/wells/RuntimePerforation.hpp
@@ -35,6 +35,12 @@ struct RuntimePerforation
 
     /// Depth at which the new connection is created.
     double depth{};
+
+    /// Segment number (1-based), if applicable (MS well).
+    int segment{};
+
+    /// MD start/end along branch if applicable (MS well).
+    std::optional<std::pair<double, double>> perf_range{};
 };
 
 } // namespace Opm


### PR DESCRIPTION
In particular, create data members for storing the segment number and the tubing lengths.  It is likely that we'll need to amend this information as need arises.