### PR TITLE
Add Infrastructure for Dynamic Connection Level Summary Vectors

### DIFF
--- a/opm/simulators/flow/EclWriter.hpp
+++ b/opm/simulators/flow/EclWriter.hpp
@@ -55,6 +55,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <algorithm>
+#include <cstddef>
 #include <limits>
 #include <map>
 #include <memory>
@@ -135,6 +137,9 @@ class EclWriter : public EclGenericWriter<GetPropType<TypeTag, Properties::Grid>
 
 public:
 
+    using DynamicConns =
+        std::vector<std::pair<std::string, std::vector<std::size_t>>>;
+
     static void registerParameters()
     {
         OutputModule::registerParameters();
@@ -195,6 +200,13 @@ public:
     const EquilGrid& globalGrid() const
     {
         return simulator_.vanguard().equilGrid();
+    }
+
+    void recordNewDynamicWellConns(const DynamicConns& newConns)
+    {
+        if ((this->rank_ == 0) && (this->eclIO_ != nullptr)) {
+            this->eclIO_->recordNewDynamicWellConns(newConns);
+        }
     }
 
     /*!


### PR DESCRIPTION
This commit adds support for registering new summary vectors at the connection level at runtime.  This is in support of fracturing processes which dynamically expose parts of the geometry to well flow as a fracture opens up.  We introduce the notion of "dynamic" connections, represented as a vector of pairs of well names and vectors of intersected cell IDs.  We expect that these will be created by the simulator as needed and registered with the Summary object as they become available.