### PR TITLE
Prune Geo-Mechanical Output Files at Startup

### DIFF
--- a/opm/simulators/utils/readDeck.cpp
+++ b/opm/simulators/utils/readDeck.cpp
@@ -537,6 +537,32 @@ void Opm::prepareResultOutputDirectory(const std::string&           baseName,
         R"(\.(F?(INIT|RFT|SMSPEC|UNSMRY|UNRST)|([ABCFGHSTUXYZ]\d{4})|PRT|DBG|INFO(STEP|ITER)|OPMRST|ESMRY))"
     };
 
+    // Outputs from geo-mechanical runs with or without fracturing.
+    //
+    // We match filenames of the form
+    //
+    //     s000n-baseName-0000n.pvtu
+    //     s000n-p000n-baseName-0000n.vtu
+    //     baseName.pvd
+    //     baseName-0000n.pvd
+    //     baseNameFracure_on_<well>_perf_<n>_nr.pvd
+    //     baseNameFracure_on_<well>_perf_<n>_nr-0000n.vtu
+    //
+    // some of which are specific to parallel runs while others are specific
+    // to sequential runs.  Note that we remove both parallel and sequential
+    // output files here, irrespective of the current run being parallel.
+    const auto geomechPrefix = std::string {
+        R"((s\d{4}-(p\d{4}-)?)?)"
+    };
+
+    const auto geomechSuffix = std::string {
+        R"((-\d{5}\.p?vtu)|(Fract?ure_on_[A-Z0-9]{1,8}_perf_\d+_nr(-\d{5})?\.(pvd|vtu))|(\.pvd))"
+    };
+
+    const auto geomechRegEx = std::regex {
+        '(' + geomechPrefix + ")(" + baseName + ")(" + geomechSuffix + ')'
+    };
+
     // We collect a list of files to remove in order that the directory
     // traversal not be disturbed by remove() calls.  The downside to this
     // approach is that it opens up the common race window between the "time
@@ -545,7 +571,7 @@ void Opm::prepareResultOutputDirectory(const std::string&           baseName,
 
     std::for_each(fs::directory_iterator { outputDir },
                   fs::directory_iterator {}, // End iterator
-                  [&baseName, &extensionRegEx, &fileRemovalList]
+                  [&baseName, &extensionRegEx, &geomechRegEx, &fileRemovalList]
                   (const fs::directory_entry& dirEntry)
     {
         if (! dirEntry.is_regular_file()) {
@@ -556,8 +582,9 @@ void Opm::prepareResultOutputDirectory(const std::string&           baseName,
 
         // Note: Normal string matching for the stem() since 'baseName'
         // might contain regular expression metacharacters like '+' or '-'.
-        if ((file.stem() == baseName) &&
-            std::regex_match(file.extension().string(), extensionRegEx))
+        if (((file.stem() == baseName) &&
+             std::regex_match(file.extension().string(), extensionRegEx)) ||
+            std::regex_match(file.filename().string(), geomechRegEx))
         {
             fileRemovalList.push_back(file);
         }


### PR DESCRIPTION
This PR amends the logic for removing a previous run's output files to include the VTK files generated by geo-mechanical runs too. These can be quite numerous and could potentially cause confusion for the engineer who's actively building a model.