### PR TITLE
Report Connection Level Rates::wat_frac Values

### DIFF
--- a/opm/simulators/wells/BlackoilWellModel_impl.hpp
+++ b/opm/simulators/wells/BlackoilWellModel_impl.hpp
@@ -667,14 +667,15 @@ namespace Opm {
 
                 const auto& well_indices_fracture = well->wellIndexFracture();
 
-                auto& filtrate_data = well_state.well(well->indexOfWell())
-                    .perf_data.filtrate_data;
+                auto& perf_data = well_state.well(well->indexOfWell()).perf_data;
+
+                auto& filtrate_data = perf_data.filtrate_data;
+                auto& fracture_data = perf_data.fracture_data;
 
                 const auto nperf = well->numLocalPerfs();
 
                 assert(well_indices_fracture.size() == nperf);
                 double total_flow_fracture = 0.0;
-                const auto& perf_data = well_state.well(well->indexOfWell()).perf_data;
                 for (auto perf = 0*nperf; perf < nperf; ++perf) {
                     const auto cell_idx = well->perforationData()[perf].cell_index;
                     const auto& intQuants = this->simulator_.model()
@@ -693,6 +694,8 @@ namespace Opm {
                     const Scalar well_index_fracture = well_indices_fracture[perf]
                         .wellIndex(perf_pressure);
 
+                    auto& fracture_rate = fracture_data.water_rate[perf];
+
                     assert(effective_well_index >= well_index_fracture);
                     if(effective_well_index > 0){
                         // NB! this change the well state for this value
@@ -701,9 +704,11 @@ namespace Opm {
                         double frac_fac = 1.0 - con_fac;    
                         filtrate_data.flow_factor[perf] = con_fac;
                         int np = well_state.numPhases();
-                        total_flow_fracture += frac_fac * perf_data.phase_rates[perf*np + FluidSystem::waterPhaseIdx];
+                        fracture_rate = frac_fac * perf_data.phase_rates[perf*np + FluidSystem::waterPhaseIdx];
+                        total_flow_fracture += fracture_rate;
                     }else{
                         filtrate_data.flow_factor[perf] = 0.0;
+                        fracture_rate = 0.0;
                     }
                 }
                 auto& single_wellstate = well_state.well(well->indexOfWell());

--- a/opm/simulators/wells/ConnFractureData.cpp
+++ b/opm/simulators/wells/ConnFractureData.cpp
@@ -41,6 +41,7 @@ void ConnFractureData<Scalar>::resize(std::size_t num_perf)
     this->inj_pressure.resize(num_perf);
     this->inj_bhp.resize(num_perf);
     this->inj_wellrate.resize(num_perf);
+    this->water_rate.resize(num_perf);
 }
 
 template<class Scalar>
@@ -60,6 +61,7 @@ ConnFractureData<Scalar>::serializationTestObject()
     result.inj_pressure = {250.0};
     result.inj_bhp = {200.0};
     result.inj_wellrate = {150.0};
+    result.water_rate = {123.4};
     return result;
 }
 
@@ -78,6 +80,7 @@ bool ConnFractureData<Scalar>::operator==(const ConnFractureData& rhs) const
         && (this->inj_pressure == rhs.inj_pressure)
         && (this->inj_bhp == rhs.inj_bhp)
         && (this->inj_wellrate == rhs.inj_wellrate)
+        && (this->water_rate == rhs.water_rate)
         ;
 }
 

--- a/opm/simulators/wells/ConnFractureData.hpp
+++ b/opm/simulators/wells/ConnFractureData.hpp
@@ -44,6 +44,7 @@ struct ConnFractureData {
         serializer(inj_pressure);
         serializer(inj_bhp);
         serializer(inj_wellrate);
+        serializer(water_rate);
     }
 
     static ConnFractureData serializationTestObject();
@@ -62,6 +63,7 @@ struct ConnFractureData {
     std::vector<Scalar> inj_pressure;
     std::vector<Scalar> inj_bhp;
     std::vector<Scalar> inj_wellrate;
+    std::vector<Scalar> water_rate;
 };
 
 }

--- a/opm/simulators/wells/WellState.cpp
+++ b/opm/simulators/wells/WellState.cpp
@@ -1303,6 +1303,9 @@ reportConnectionFracture(const std::size_t well_index,
         fracture.inj_pressure = data.inj_pressure[i];
         fracture.inj_bhp = data.inj_bhp[i];
         fracture.inj_wellrate = data.inj_wellrate[i];
+
+        connections[i].rates.set(data::Rates::opt::wat_frac,
+                                 data.water_rate[i]);
     }
 }
 


### PR DESCRIPTION
This enables calculating more new water injection summary vectors that in turn enable analysing the fractions attributable to fracture flow.  In particular, we now enable calculating the following connection level summary vectors

  - `CWIRFRAC`&ndash;Connection level water injection rate in fracture
  - `CWITFRAC`&ndash;Connection level cumulative injection volume in fracture